### PR TITLE
Implemented changes for #144 (command line, custom uri schema & robust client-side api)

### DIFF
--- a/gamevault/App.xaml.cs
+++ b/gamevault/App.xaml.cs
@@ -98,7 +98,11 @@ namespace gamevault
 
             // After the app is created and most things are instantiated, handle any special command line stuff
             if (PipeServiceHandler.Instance != null)
+            {
+                // Strictly speaking we should hold up all commands until we have a confirmed login & setup is complete, but for now we'll assume that auto-login has worked
+                PipeServiceHandler.Instance.IsReadyForCommands = true;
                 await PipeServiceHandler.Instance.HandleCommand(App.CommandLineOptions);
+            }
         }
 
         private void AppDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)

--- a/gamevault/Helper/WebHelper.cs
+++ b/gamevault/Helper/WebHelper.cs
@@ -57,6 +57,24 @@ namespace gamevault.Helper
                 return reader.ReadToEnd();
             }
         }
+        internal static async Task<string> GetRequestAsync(string uri)
+        {
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+#if DEBUG
+            request.Timeout = 3000;
+#endif
+            request.UserAgent = $"GameVault/{SettingsViewModel.Instance.Version}";
+            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            var authenticationString = $"{m_UserName}:{m_Password}";
+            var base64EncodedAuthenticationString = Convert.ToBase64String(System.Text.ASCIIEncoding.UTF8.GetBytes(authenticationString));
+            request.Headers.Add("Authorization", "Basic " + base64EncodedAuthenticationString);
+            using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync())
+            using (Stream stream = response.GetResponseStream())
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                return await reader.ReadToEndAsync();
+            }
+        }
         internal static string Put(string uri, string payload, bool returnBody = false)
         {
             var request = (HttpWebRequest)WebRequest.Create(uri);

--- a/gamevault/Models/CommandOptions.cs
+++ b/gamevault/Models/CommandOptions.cs
@@ -1,0 +1,307 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Web;
+using CommandLine;
+using CommandLine.Text;
+
+namespace gamevault.Models
+{
+    /// <summary>
+    /// The base CommandOptions class, used for parsing command line options and passing data between different instances of the running process
+    /// </summary>
+    [Verb("<none>", isDefault: true, Hidden = true)]
+    public class CommandOptions
+    {
+        /// <summary>
+        /// The types of command line options supported
+        /// </summary>
+        public static readonly Type[] CommandLineTypes = new Type[] {
+            typeof(CommandOptions),
+            typeof(CommandOptions_Show),
+            typeof(CommandOptions_Install),
+            typeof(CommandOptions_Uninstall),
+            typeof(CommandOptions_Start),
+
+#if false
+            typeof(CommandOptions_Stop)
+#endif
+        };
+
+        /// <summary>
+        /// The types of command line options supported
+        /// </summary>
+        public enum ActionEnum
+        {
+            /// <summary>
+            /// Show the main application or specific game
+            /// </summary>
+            Show,
+
+            /// <summary>
+            /// Install a game
+            /// </summary>
+            Install,
+
+            /// <summary>
+            /// Uninstall a game
+            /// </summary>
+            Uninstall,
+
+            /// <summary>
+            /// Start a game
+            /// </summary>
+            Start,
+
+            /// <summary>
+            /// Stop a game or all games
+            /// </summary>
+            Stop,
+
+            // A means by which other programs can interact with our Pipe to ask for simple information
+            // It is NOT a replacement for the Gamevault Backend API
+            Query
+        }
+
+        /// <summary>
+        /// The type of action to perform
+        /// </summary>
+        [Option("action", Required = false, Hidden = true)]
+        public virtual ActionEnum Action { get; set; } = ActionEnum.Show;
+
+        /// <summary>
+        /// Whether or not this should happen in the background or bring the main window to the foreground
+        /// </summary>
+        [Option("minimized", Required = false, Hidden = true)]
+        public virtual bool? Minimized { get; set; } = null;
+
+        /// <summary>
+        /// The id of the game to action on
+        /// </summary>
+        [Option("gameid", Required = false, Hidden = true)]
+        public virtual int? GameId { get; set; } = null;
+
+        /// <summary>
+        /// Whether or not to auto install (used by <see cref="ActionEnum.Start"/> ).
+        /// </summary>
+        [Option("autoinstall", Required = false, Hidden = true)]
+        public virtual bool? AutoInstall { get; set; } = null;
+
+        /// <summary>
+        /// The type of query to do ( used by <see cref="ActionEnum.Query"/> ).
+        /// Available options are in <see cref="PipeServiceHandler.ActionQueryEnum"/>
+        /// </summary>
+        [Option("query", Required = false, Hidden = true)]
+        public virtual string? Query { get; set; }
+
+        /// <summary>
+        /// The uri data sent to the application via gamevault:// .
+        /// This is a string representation of this <see cref="CommandOptions"/>
+        /// </summary>
+        [Option("uridata", Required = false, Hidden = true)]
+        public string UriData
+        {
+            get => this.SerializeToUri();
+            set => this.ParseFromUri(value);
+        }
+
+        /// <summary>
+        /// The map of getters and setters for each property that needs to be (de)serialized to/from the <see cref="UriData"/>
+        /// </summary>
+        private static readonly Dictionary<string, (Func<CommandOptions, string?> get, Action<CommandOptions, string> set)> GettersAndSetters = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { nameof(Minimized), (
+                get: opt => opt.Minimized.HasValue ? opt.Minimized.ToString() : null,
+                set: (opt, val) => { if (bool.TryParse(val, out var m)) opt.Minimized = m; }) },
+
+            { nameof(GameId), (
+                get: opt => opt.GameId.HasValue ? opt.GameId.ToString() : null,
+                set: (opt, val) => { if (int.TryParse(val, out var id)) opt.GameId = id; }) },
+
+            { nameof(AutoInstall), (
+                get: opt => opt.AutoInstall.HasValue ? opt.AutoInstall.ToString() : null,
+                set: (opt, val) => { if (bool.TryParse(val, out var m)) opt.AutoInstall = m; }) },
+
+            { nameof(Query), (
+                get: opt => opt.Query,
+                set: (opt, val) => { opt.Query = val; }) },
+        };
+
+        /// <summary>
+        /// Serializes this <see cref="CommandOptions"/> to a uri ( gamevault://action?param=value )
+        /// </summary>
+        private string SerializeToUri()
+        {
+            StringBuilder uri = new StringBuilder();
+
+            uri.Append($"{PipeServiceHandler.GAMEVAULT_URI_SCHEME}://");
+            uri.Append($"{Enum.GetName(this.Action)}");
+
+            uri.Append('?');
+
+            foreach (var getterAndSetter in GettersAndSetters)
+            {
+                var value = getterAndSetter.Value.get(this);
+
+                if (!string.IsNullOrEmpty(value))
+                {
+                    uri.Append($"{HttpUtility.UrlEncode(getterAndSetter.Key)}={HttpUtility.UrlEncode(value)}&");
+                }
+            }
+
+            // Remove the trailing &
+            if (uri[uri.Length - 1] == '&')
+                uri.Remove(uri.Length - 1, 1);
+
+            return uri.ToString();
+        }
+
+        /*
+gamevault:action?something=true
+gamevault://action?something=true
+gamevault://action/?something=true
+gamevault://///action/////?something=true
+gamevault-2://action?something=true
+gamevault:action
+gamevault://action
+action?something=true
+action
+        */
+        private static readonly System.Text.RegularExpressions.Regex matchUriRegex = new System.Text.RegularExpressions.Regex(@"
+^
+(?:[\w\-]+:/*)?
+(?<action>\w+) \/* \?*
+(?<params>.*)?
+$",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace | System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>
+        /// Parses a uri ( gamevault://action?param=value )
+        /// </summary>
+        private void ParseFromUri(string? uri)
+        {
+            if (string.IsNullOrEmpty(uri))
+                return;
+
+            var match = matchUriRegex.Match(uri);
+
+            if (!match.Success)
+            {
+                // An invalid uri was passed (which should be impossible since we accept almost anything)
+                return;
+            }
+
+            string action = match.Groups["action"].Value;
+            string? parameters = null;
+
+            if (match.Groups["params"].Success)
+                parameters = match.Groups["params"].Value;
+
+            if (Enum.TryParse<ActionEnum>(action, true, out var actionEnum))
+            {
+                this.Action = actionEnum;
+            }
+            else
+            {
+                System.Windows.MessageBox.Show($"Invalid action: {action}", "Error", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
+            }
+
+            if (!string.IsNullOrEmpty(parameters))
+            {
+                var paramsSplit = parameters.Split('&', StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (var param in paramsSplit)
+                {
+                    var splitParam = param.Split('=', 2, StringSplitOptions.TrimEntries);
+
+                    if (splitParam.Length != 2)
+                    {
+                        // An invalid param was passed
+                        continue;
+                    }
+
+                    var property = HttpUtility.UrlDecode(splitParam[0]);
+                    var value = HttpUtility.UrlDecode(splitParam[1]);
+
+                    if (GettersAndSetters.TryGetValue(property, out var getterAndSetter))
+                    {
+                        getterAndSetter.set(this, value);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a <see cref="CommandOptions"/> from the provided uri ( gamevault://action?param=value )
+        /// </summary>
+        public static CommandOptions CreateFromUri(string? uri)
+        {
+            CommandOptions options = new CommandOptions();
+
+            options.ParseFromUri(uri);
+
+            return options;
+        }
+    }
+
+    #region Verb instances of CommandOptions
+
+    [Verb(nameof(ActionEnum.Show), HelpText = "Open or show GameVault, optionally to a specific game.")]
+    public class CommandOptions_Show : CommandOptions
+    {
+        public override ActionEnum Action { get => ActionEnum.Show; set => base.Action = ActionEnum.Show; }
+
+        [Option("minimized", Required = false, HelpText = "Start minimized.")]
+        public new bool Minimized { get => base.Minimized.GetValueOrDefault(); set => base.Minimized = value; }
+
+        [Option("gameid", Required = false, HelpText = $"The {nameof(Game.ID)} of the game to show, or null to simply open GameVault.", Default = null)]
+        public override int? GameId { get => base.GameId; set => base.GameId = value; }
+    }
+
+    [Verb(nameof(ActionEnum.Install), HelpText = "Install a game into GameVault.")]
+    public class CommandOptions_Install : CommandOptions
+    {
+        public override ActionEnum Action { get => ActionEnum.Install; set => base.Action = ActionEnum.Install; }
+
+        [Option("gameid", Required = true, HelpText = $"The {nameof(Game.ID)} of the game to install.")]
+        public new int GameId { get => base.GameId.GetValueOrDefault(); set => base.GameId = value; }
+    }
+
+    [Verb(nameof(ActionEnum.Uninstall), HelpText = "Uninstall a game from GameVault.")]
+    public class CommandOptions_Uninstall : CommandOptions
+    {
+        public override ActionEnum Action { get => ActionEnum.Uninstall; set => base.Action = ActionEnum.Uninstall; }
+
+        [Option("gameid", Required = true, HelpText = $"The {nameof(Game.ID)} of the game to uninstall.")]
+        public new int GameId { get => base.GameId.GetValueOrDefault(); set => base.GameId = value; }
+    }
+
+    [Verb(nameof(ActionEnum.Start), HelpText = "Start a game, installing it if necessary.")]
+    public class CommandOptions_Start : CommandOptions
+    {
+        public override ActionEnum Action { get => ActionEnum.Start; set => base.Action = ActionEnum.Start; }
+
+        [Option("gameid", Required = true, HelpText = $"The {nameof(Game.ID)} of the game to start.")]
+        public new int GameId { get => base.GameId.GetValueOrDefault(); set => base.GameId = value; }
+
+        [Option("autoinstall", Required = false, HelpText = "Install the game if it's not already installed.", Default = true)]
+        public new bool AutoInstall { get => base.AutoInstall.GetValueOrDefault(); set => base.AutoInstall = value; }
+    }
+
+#if false
+    Explicitly disabled STOP since we don't support that until we track active games
+    Remove this message which causes a syntax error if implemented
+
+    [Verb(nameof(ActionEnum.Stop), HelpText = "Stop a specific game or all games currently opened by GameVault.")]
+    public class CommandOptions_Stop : CommandOptions
+    {
+        public override ActionEnum Action { get => ActionEnum.Stop; set => base.Action = ActionEnum.Stop; }
+
+        [Option("gameid", Required = true, HelpText = $"The {nameof(Game.ID)} of the game to stop, or null to just close any open games.", Default = null)]
+        public override int? GameId { get => base.GameId; set => base.GameId = value; }
+    }
+#endif
+
+    #endregion
+}

--- a/gamevault/PipeServiceHandler.cs
+++ b/gamevault/PipeServiceHandler.cs
@@ -570,6 +570,11 @@ namespace gamevault
             GetName,
 
             /// <summary>
+            /// Returns the install directory of the game
+            /// </summary>
+            GetInstallDirectory,
+
+            /// <summary>
             /// Returns the version of the app
             /// </summary>
             GetAppVersion,
@@ -582,7 +587,8 @@ namespace gamevault
             /// <summary>
             /// Returns true/false depending on if the user is logged in
             /// </summary>
-            IsLoggedIn
+            IsLoggedIn,
+
         }
 
         /// <summary>
@@ -644,6 +650,20 @@ namespace gamevault
                             game = await GetServerGame(options.GameId.Value);
 
                         return game?.Title ?? "error: game not found";
+                    }
+                case ActionQueryEnum.GetInstallDirectory:
+                    {
+                        if (!options.GameId.HasValue)
+                            return "error: no game id";
+
+                        var game = await GetInstalledGame(options.GameId.Value);
+
+                        if (game == null)
+                            return "";
+
+                        var installDirectory = InstallViewModel.Instance.InstalledGames.Where(g => g.Key.ID == game.ID).Select(g => g.Value).FirstOrDefault();
+
+                        return installDirectory ?? "";
                     }
                 case ActionQueryEnum.GetServerUrl:
                     return SettingsViewModel.Instance.ServerUrl;

--- a/gamevault/PipeServiceHandler.cs
+++ b/gamevault/PipeServiceHandler.cs
@@ -1,0 +1,694 @@
+﻿using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Security.Principal;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Windows;
+using gamevault.Helper;
+using gamevault.Models;
+using gamevault.ViewModels;
+using Windows.Devices.Sms;
+
+namespace gamevault
+{
+    /// <summary>
+    /// Provides a client-side API to & from the main running instance of the application
+    /// </summary>
+    public class PipeServiceHandler
+    {
+        /// <summary>
+        /// The URI scheme used for communication
+        /// </summary>
+        public const string GAMEVAULT_URI_SCHEME = "gamevault";
+
+        /// <summary>
+        /// The friendly name of the URI
+        /// </summary>
+        private const string GAMEVAULT_URI_NAME = "GameVault App";
+
+        /// <summary>
+        /// The name of the named pipe
+        /// </summary>
+        private const string GAMEVAULT_PIPE_NAME = "GameVault";
+
+        /// <summary>
+        /// The singleton instance of the handler, which is not null after the application has started
+        /// </summary>
+        public static PipeServiceHandler? Instance { get; private set; }
+
+        private PipeServiceHandler()
+        {
+        }
+
+        /// <summary>
+        /// Starts the handler
+        /// </summary>
+        public static void StartInstance()
+        {
+            if (Instance != null)
+                return;
+
+            Instance = new PipeServiceHandler();
+
+            Instance.RegisterUriScheme();
+
+            try
+            {
+                Instance.StartNamedPipeServer();
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show(ex.Message, "An error while startin the internal pipe server", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
+            }
+        }
+
+        /// <summary>
+        /// Registers the URI scheme which lets other applications communicate with the application
+        /// </summary>
+        private void RegisterUriScheme()
+        {
+            string? executablePath = null;
+
+            // winexe does not easily support getting our .exe file
+            //executablePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
+            // so get it from the process
+            executablePath = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
+
+            if (string.IsNullOrEmpty(executablePath))
+                return;
+
+#if WINDOWS
+            var view = Microsoft.Win32.RegistryView.Registry32;
+            if (Environment.Is64BitOperatingSystem)
+                view = Microsoft.Win32.RegistryView.Registry64;
+
+            using var root = Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.CurrentUser, view);
+            using var classes = root.OpenSubKey(@"Software\Classes", true)!;
+
+            var openString = $"\"{executablePath}\" --uridata \"%1\"";
+            using var existing = classes.OpenSubKey(@$"{GAMEVAULT_URI_SCHEME}\shell\open\command");
+
+            if (existing != null && existing.GetValue("")?.ToString() == openString)
+                return;
+
+            using var newEntry = classes.CreateSubKey(GAMEVAULT_URI_SCHEME);
+            newEntry.SetValue("", $"URL:{GAMEVAULT_URI_NAME}");
+            newEntry.SetValue("URL Protocol", "");
+
+            using var command = newEntry.CreateSubKey(@"shell\open\command");
+            command.SetValue("", openString);
+#endif
+        }
+
+        /// <summary>
+        /// Starts the named pipe server which accepts connections.
+        /// The named pipe will run on a background task (which should be a separate thread).
+        /// </summary>
+        private void StartNamedPipeServer()
+        {
+            _ = Task.Factory.StartNew(async () =>
+            {
+                var pipeSecurity = new PipeSecurity();
+
+                // Allow all users on the current machine to connect
+                pipeSecurity.AddAccessRule(new PipeAccessRule(
+                    new SecurityIdentifier(WellKnownSidType.WorldSid, null),
+                    PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance,
+                    System.Security.AccessControl.AccessControlType.Allow));
+
+                while (true)
+                {
+                    // Each time we accept a connection, we create a new named pipe
+
+                    try
+                    {
+                        var server = NamedPipeServerStreamAcl.Create(GAMEVAULT_PIPE_NAME, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances,
+                            PipeTransmissionMode.Byte, PipeOptions.None, 0, 0, pipeSecurity);
+
+                        await server.WaitForConnectionAsync().ConfigureAwait(false);
+
+                        // Handle the pipe in the background, so we don't block our thread and can handle the next connection asap
+                        _ = HandlePipeConnection(server).ConfigureAwait(false);
+                    }
+                    catch (Exception) { }
+                }
+            }, TaskCreationOptions.LongRunning).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Handles a single pipe connection
+        /// </summary>
+        private async Task HandlePipeConnection(NamedPipeServerStream server)
+        {
+            // There is no loop inside this method since we only accept a SINGLE message and then close the connection
+            // It might be possible to have a persistent connection in the future, in which case this would need to keep the pipe open
+
+            StreamWriter? writer = null;
+            StreamReader? reader = null;
+
+            try
+            {
+                string? message = null;
+
+                reader = new StreamReader(server, leaveOpen: true);
+
+                message = await reader.ReadLineAsync().ConfigureAwait(false);
+
+                if (!string.IsNullOrEmpty(message))
+                {
+                    var response = await HandleMessage(message).ConfigureAwait(false);
+
+                    if (!string.IsNullOrEmpty(response))
+                    {
+                        // It's possible we get a response to send back (query), so do that
+                        writer = new StreamWriter(server, leaveOpen: true) { AutoFlush = true };
+                        await writer.WriteLineAsync(response).ConfigureAwait(false);
+                    }
+                }
+            }
+            finally
+            {
+                // Safely dispose anything we created
+                SafeDispose(writer);
+                SafeDispose(reader);
+                SafeDispose(server);
+            }
+        }
+
+        /// <summary>
+        /// Sends a single message to the main running instance
+        /// </summary>
+        /// <param name="message">The message to send (which should be an uri form)</param>
+        /// <param name="expectsResult">True if we expect a response (such as from a Query)</param>
+        /// <returns></returns>
+        public static async Task<string?> SendMessage(string message, bool expectsResult = false)
+        {
+            string? result = null;
+            var client = new NamedPipeClientStream(GAMEVAULT_PIPE_NAME);
+            StreamWriter? writer = null;
+            StreamReader? reader = null;
+
+            try
+            {
+                await client.ConnectAsync();
+
+                writer = new StreamWriter(client, leaveOpen: true) { AutoFlush = true };
+                await writer.WriteLineAsync(message);
+
+                if (expectsResult)
+                {
+                    reader = new StreamReader(client, leaveOpen: true);
+                    result = await reader.ReadLineAsync();
+                }
+            }
+            finally
+            {
+                SafeDispose(writer);
+                SafeDispose(reader);
+                SafeDispose(client);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Safely dispose anything without throwing an error if it's already disposed or closed or whatever
+        /// </summary>
+        /// <param name="disposable">The object to dispose</param>
+        private static void SafeDispose(IDisposable? disposable)
+        {
+            if (disposable == null)
+                return;
+
+            try
+            {
+                disposable.Dispose();
+            }
+            catch (Exception) { }
+        }
+
+        /// <summary>
+        /// Handles a single message sent to this instance
+        /// </summary>
+        /// <param name="message">The message to handle</param>
+        /// <returns>A response if required (such as from a Query)</returns>
+        private async Task<string?> HandleMessage(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+                return null;
+
+            CommandOptions opts;
+
+            if (message.Equals("ShowMainWindow", StringComparison.OrdinalIgnoreCase))
+            {
+                // ShowMainWindow is a legacy message which we don't pass around anymore
+                // But it's possible (unlikely) that other applications are sending it
+                // Remove in the future if we don't need it
+                opts = new CommandOptions() { Action = CommandOptions.ActionEnum.Show };
+            }
+            else
+            {
+                // Parse the message
+                opts = CommandOptions.CreateFromUri(message);
+            }
+
+            return await HandleCommand(opts);
+        }
+
+        /// <summary>
+        /// Handles a command (which could be potentially our command line options)
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public async Task<string?> HandleCommand(CommandOptions? options)
+        {
+            if (options == null)
+                return null;
+
+            bool showMainWindow = false;
+            bool isGameInstalled = false;
+            Task? task = null;
+
+            if (options.GameId.HasValue)
+            {
+                // There's a gameid and most of our actions want to know if it's already installed
+                isGameInstalled = await GetInstalledGame(options.GameId.Value) != null;
+            }
+
+            // do stuff
+            switch (options.Action)
+            {
+                case CommandOptions.ActionEnum.Show:
+                    showMainWindow = true;
+
+                    if (options.GameId.HasValue)
+                    {
+                        task = ShowGame(options.GameId.Value);
+                    }
+                    break;
+                case CommandOptions.ActionEnum.Install:
+                    if (options.GameId.HasValue)
+                    {
+                        showMainWindow = true;
+
+                        if (!isGameInstalled)
+                            task = InstallGame(options.GameId.Value);
+                        else
+                            task = ShowGame(options.GameId.Value);
+                    }
+                    break;
+                case CommandOptions.ActionEnum.Uninstall:
+                    showMainWindow = isGameInstalled;
+                    if (options.GameId.HasValue)
+                    {
+                        showMainWindow = true;
+
+                        if (isGameInstalled)
+                            task = UninstallGame(options.GameId.Value);
+                        else
+                            task = ShowGame(options.GameId.Value);
+                    }
+                    break;
+                case CommandOptions.ActionEnum.Start:
+                    if (options.GameId.HasValue)
+                    {
+                        if (!isGameInstalled)
+                        {
+                            showMainWindow = true;
+
+                            if (options.AutoInstall == true)
+                                task = InstallGame(options.GameId.Value);
+                            else
+                                task = ShowGame(options.GameId.Value);
+                        }
+                        else
+                        {
+                            showMainWindow = false;
+
+                            task = StartGame(options.GameId.Value);
+                        }
+                    }
+                    break;
+                case CommandOptions.ActionEnum.Stop:
+                    showMainWindow = false;
+
+                    task = StopGame(options.GameId);
+                    break;
+                case CommandOptions.ActionEnum.Query:
+                    // Shortcut the return since we absolutely never want to show the UI if we're doing a query
+                    return await HandleQuery(options);
+                default:
+                    // You should really implement new actions that you add
+                    throw new NotImplementedException($"Action {options.Action} not implemented");
+            }
+
+            if (options.Minimized.HasValue)
+            {
+                // If we're provided a Minimized value then we can explicitly use that for whether or not to be shown
+                showMainWindow = !options.Minimized.Value;
+            }
+
+            if (showMainWindow)
+            {
+                // Dispatch is used to ensure that we're on the UI thread
+                await Dispatch(() =>
+                {
+                    var mainWindow = System.Windows.Application.Current.MainWindow;
+
+                    if (mainWindow != null)
+                    {
+                        // Make visible
+                        mainWindow.Show();
+
+                        // Restore
+                        if (mainWindow.WindowState == System.Windows.WindowState.Minimized)
+                            mainWindow.WindowState = System.Windows.WindowState.Normal;
+
+                        // Bring to foreground
+                        mainWindow.Activate();
+                    }
+                });
+
+
+                if (task != null)
+                    await task;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get an installed game
+        /// </summary>
+        /// <param name="id">The game id</param>
+        /// <returns>The game or null if not installed</returns>
+        private async Task<Game?> GetInstalledGame(int id)
+        {
+            if (!InstallViewModel.Instance.InstalledGames.Any())
+            {
+                await MainWindowViewModel.Instance.Library.GetGameInstalls().RestoreInstalledGames();
+            }
+
+            return InstallViewModel.Instance.InstalledGames.Where(g => g.Key.ID == id).Select(g => g.Key).FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Get a game from the server or offline cache
+        /// </summary>
+        /// <param name="id">The game id</param>
+        /// <returns>The game or null if not found</returns>
+        private async Task<Game?> GetServerGame(int id)
+        {
+            Game? game = null;
+
+            if (LoginManager.Instance.IsLoggedIn())
+            {
+                try
+                {
+                    string result = await WebHelper.GetRequestAsync(@$"{SettingsViewModel.Instance.ServerUrl}/api/games/{id}");
+                    game = JsonSerializer.Deserialize<Game>(result);
+                }
+                catch (Exception)
+                {
+
+                }
+            }
+            
+            if (game == null)
+            {
+                string compressedStringObject = Preferences.Get(id.ToString(), AppFilePath.OfflineCache);
+                if (!string.IsNullOrEmpty(compressedStringObject))
+                {
+                    string decompressedObject = StringCompressor.DecompressString(compressedStringObject);
+                    Game? deserializedObject = JsonSerializer.Deserialize<Game>(decompressedObject);
+                    game = deserializedObject;
+                }
+            }
+
+            return game;
+        }
+
+        /// <summary>
+        /// Start a game
+        /// </summary>
+        private async Task StartGame(int id)
+        {
+            var game = await GetInstalledGame(id);
+
+            if (game == null)
+                return;
+
+            // Ensure we're on the UI thread
+            await Dispatch(() =>
+            {
+                var gameViewUserControl = new UserControls.GameViewUserControl(game, false);
+
+                // Set the correct UI regardless of if it's visible to let the user manage it
+                MainWindowViewModel.Instance.SetActiveControl(gameViewUserControl);
+
+                gameViewUserControl.GamePlay();
+            });
+        }
+
+        /// <summary>
+        /// Stop a game
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        private async Task StopGame(int? id)
+        {
+            if (id.HasValue)
+            {
+                var game = await GetInstalledGame(id.Value);
+
+                if (game == null)
+                    return;
+            }
+
+            // Can't implement this yet since we don't actually track games that are running or stopped
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Uninstall a game
+        /// </summary>
+        private async Task UninstallGame(int id)
+        {
+            var game = await GetInstalledGame(id);
+
+            if (game == null)
+                return;
+
+            // Ensure we're on the UI thread
+            await Dispatch(async () =>
+            {
+                var gameSettingsUserControl = new UserControls.GameSettingsUserControl(game);
+
+                // Would be nice to have this all in the background but there's potentially multiple popups that could have multiple options
+                MainWindowViewModel.Instance.OpenPopup(gameSettingsUserControl);
+
+                await gameSettingsUserControl.UninstallGame();
+            });
+        }
+
+        /// <summary>
+        /// Install a game
+        /// </summary>
+        private async Task InstallGame(int id)
+        {
+            var game = await GetInstalledGame(id);
+
+            // Check if the game is already installed
+            if (game == null)
+            {
+                game = await GetServerGame(id);
+
+                if (game == null)
+                {
+                    MessageBox.Show($"Game with ID {id} not found", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
+
+                // Ensure we're on the UI thread
+                await Dispatch(async () =>
+                {
+                    await MainWindowViewModel.Instance.Downloads.TryStartDownload(game);
+                    MainWindowViewModel.Instance.SetActiveControl(MainWindowViewModel.Instance.Downloads);
+                });
+
+                // Let user hit the Install button since the UI is complicated and doesn't support auto installing anyway
+            }
+        }
+
+        /// <summary>
+        /// Show a specific game
+        /// </summary>
+        private async Task ShowGame(int id)
+        {
+            var game = await GetInstalledGame(id);
+
+            if (game == null)
+                game = await GetServerGame(id);
+
+            if (game != null)
+            {
+                // Ensure we're on the UI thread
+                await Dispatch(() =>
+                {
+                    var gameViewUserControl = new UserControls.GameViewUserControl(game, false);
+                    MainWindowViewModel.Instance.SetActiveControl(gameViewUserControl);
+                });
+            }
+            else
+            {
+                MessageBox.Show($"Game with ID {id} not found", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        public enum ActionQueryEnum
+        {
+            /// <summary>
+            /// Returns true/false depending on if the game exists (installed or not)
+            /// </summary>
+            Exists,
+
+            /// <summary>
+            /// Returns true/false depending on if the game is downloaded
+            /// </summary>
+            Downloaded,
+
+            /// <summary>
+            /// Returns true/false depending on if the game is installed
+            /// </summary>
+            Installed,
+
+            /// <summary>
+            /// Returns the name of the game
+            /// </summary>
+            GetName,
+
+            /// <summary>
+            /// Returns the version of the app
+            /// </summary>
+            GetAppVersion,
+
+            /// <summary>
+            /// Returns the server url used by the app
+            /// </summary>
+            GetServerUrl,
+
+            /// <summary>
+            /// Returns true/false depending on if the user is logged in
+            /// </summary>
+            IsLoggedIn
+        }
+
+        /// <summary>
+        /// Handles a query (<see cref="CommandOptions.ActionEnum.Query"/>) with a <see cref="CommandOptions.Query"/> of the enum type <see cref="ActionQueryEnum"/>
+        /// </summary>
+        /// <returns>The result of the query OR a string prefixed with "error: " if there was an error</returns>
+        /// <exception cref="NotImplementedException">If the relevant <see cref="ActionQueryEnum"/> is not implemented</exception>
+        private async Task<string> HandleQuery(CommandOptions options)
+        {
+            if (!Enum.TryParse<ActionQueryEnum>(options.Query, true, out var query))
+                return "error: invalid query";
+
+            switch (query)
+            {
+                case ActionQueryEnum.Exists:
+                    {
+                        if (!options.GameId.HasValue)
+                            return "error: no game id";
+
+                        var game = await GetInstalledGame(options.GameId.Value);
+
+                        if (game == null)
+                            game = await GetServerGame(options.GameId.Value);
+
+                        return (game != null).ToString();
+                    }
+                case ActionQueryEnum.Downloaded:
+                    {
+                        if (!options.GameId.HasValue)
+                            return "error: no game id";
+
+                        var downloaded = false;
+                        var game = await GetInstalledGame(options.GameId.Value);
+
+                        if (game == null)
+                            downloaded = true;
+                        else if (DownloadsViewModel.Instance.DownloadedGames.Any(g => g.GetGameId() == options.GameId.Value))
+                            downloaded = true;
+
+                        return downloaded.ToString();
+                    }
+                case ActionQueryEnum.Installed:
+                    {
+                        if (!options.GameId.HasValue)
+                            return "error: no game id";
+
+                        var game = await GetInstalledGame(options.GameId.Value);
+
+                        return (game != null).ToString();
+                    }
+                case ActionQueryEnum.GetName:
+                    {
+                        if (!options.GameId.HasValue)
+                            return "error: no game id";
+
+                        var game = await GetInstalledGame(options.GameId.Value);
+
+                        if (game == null)
+                            game = await GetServerGame(options.GameId.Value);
+
+                        return game?.Title ?? "error: game not found";
+                    }
+                case ActionQueryEnum.GetServerUrl:
+                    return SettingsViewModel.Instance.ServerUrl;
+                case ActionQueryEnum.GetAppVersion:
+                    return SettingsViewModel.Instance.Version;
+                case ActionQueryEnum.IsLoggedIn:
+                    return LoginManager.Instance.IsLoggedIn().ToString();
+                default:
+                    // You should really implement new Action Queries
+                    throw new NotImplementedException($"Query {query} not implemented");
+            }
+        }
+
+        /// <summary>
+        /// Dispatches an action on the UI thread (if available)
+        /// </summary>
+        private async Task Dispatch(Action action)
+        {
+            var dispatcher = System.Windows.Application.Current.Dispatcher;
+
+            if (dispatcher != null)
+            {
+                await dispatcher.InvokeAsync(action);
+            }
+            else
+            {
+                action.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Dispatches an async action on the UI thread (if available)
+        /// </summary>
+        private async Task Dispatch(Func<Task> action)
+        {
+            var dispatcher = System.Windows.Application.Current.Dispatcher;
+
+            if (dispatcher != null)
+            {
+                await dispatcher.InvokeAsync(action);
+            }
+            else
+            {
+                await action.Invoke();
+            }
+        }
+    }
+}

--- a/gamevault/Program.cs
+++ b/gamevault/Program.cs
@@ -127,7 +127,7 @@ namespace gamevault
                 if (cmdLineOptions.Action == CommandOptions.ActionEnum.Query)
                 {
                     // We're sending a query through the pipe, this is mostly for debugging
-                    var result = PipeServiceHandler.SendMessage(cmdLineOptions.UriData!, expectsResult: true).Result;
+                    var result = PipeServiceHandler.SendMessage(cmdLineOptions.UriData!, expectsResult: true).GetAwaiter().GetResult();
 
                     result = result?.Trim('\r', '\n');
 
@@ -139,7 +139,7 @@ namespace gamevault
                     return;
                 }
 
-                PipeServiceHandler.SendMessage(cmdLineOptions.UriData, expectsResult: false).Wait();
+                PipeServiceHandler.SendMessage(cmdLineOptions.UriData, expectsResult: false).GetAwaiter().GetResult();
                 Environment.Exit(1);
                 return;
             }

--- a/gamevault/Program.cs
+++ b/gamevault/Program.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Interop;
+using CommandLine;
+using gamevault.Models;
+
+namespace gamevault
+{
+    /// <summary>
+    /// Main entry point
+    /// </summary>
+    public class Program
+    {
+        // Unique ID for the mutex, which will not be shared by another application
+        private const string GAMEVAULT_MUTEX = "0C8E52D8-ECD4-4F12-95B5-CE3412C073EA:GameVault";
+
+        /// <summary>
+        /// The main entry point for the application.
+        /// This will load the minimal number of dlls needed before passing off to the main UI.
+        /// </summary>
+        /// <param name="args">Args passed to the application from the command line</param>
+        [STAThread]
+        public static void Main(string[] args)
+        {
+            CommandOptions cmdLineOptions;
+
+            using (var parser = new Parser(with =>
+            {
+                with.AutoVersion = true;
+                with.AutoHelp = true;
+                with.HelpWriter = null;
+
+                with.CaseInsensitiveEnumValues = true;
+                with.CaseSensitive = false;
+                with.IgnoreUnknownArguments = true;
+            }))
+            {
+                var cmdLineParserResult = parser.ParseArguments(args, CommandOptions.CommandLineTypes);
+
+                #region Command Line Help
+
+                cmdLineParserResult.WithNotParsed(errors =>
+                {
+                    // We only treat uri requests differently for the sake of help, otherwise it's parsed automatically
+                    var isFromUri = args.Any(x => x.StartsWith("--uridata", StringComparison.OrdinalIgnoreCase));
+
+                    var help = CommandLine.Text.HelpText.AutoBuild(cmdLineParserResult, help =>
+                    {
+                        help.Copyright = ""; // TODO: Add GameVault copyright information
+                                             //       ALTERNATIVELY, just add it to AssemblyInfo.cs
+
+                        help.AddEnumValuesToHelpText = true;
+                        help.AddNewLineBetweenHelpSections = true;
+                        help.AdditionalNewLineAfterOption = false;
+
+                        // Attempt to get the actual verb used
+                        var action = errors.OfType<HelpVerbRequestedError>().FirstOrDefault()?.Verb ?? "<action>";
+
+                        help.AddPreOptionsLine(Environment.NewLine);
+
+                        if (isFromUri)
+                        {
+                            // URI help
+                            help.AddDashesToOption = false;
+                            help.AddPreOptionsLine($"USAGE: {PipeServiceHandler.GAMEVAULT_URI_SCHEME}://{action}?[param=value]&...");
+                        }
+                        else
+                        {
+                            // Default in case we can't determine the actual executable
+                            var executable = "gamevault.exe";
+
+                            // winexe does not easily support getting our .exe file
+                            //var executablePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
+                            // so get it from the process
+                            var executablePath = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
+
+                            if (!string.IsNullOrEmpty(executablePath))
+                                executable = Path.GetFileName(executablePath);
+
+                            help.AddPreOptionsLine($"USAGE: {executable} {action} [param=value] ...");
+                        }
+
+                        return CommandLine.Text.HelpText.DefaultParsingErrorsHandler(cmdLineParserResult, help);
+                    }, maxDisplayWidth: 600);
+
+                    // We can't return help on the command line, so show a message box instead
+                    System.Windows.MessageBox.Show(
+                        help.ToString(),
+                        "Help",
+                        System.Windows.MessageBoxButton.OK,
+                        System.Windows.MessageBoxImage.Information);
+
+                    if (errors.Any(e => e.StopsProcessing))
+                        Environment.Exit(1);
+
+                    return;
+                });
+
+                #endregion Command Line Help
+
+                // Downgrade to CommandOptions which can be treated generically
+                if (cmdLineParserResult?.Value is CommandOptions commandOptions)
+                    cmdLineOptions = commandOptions;
+                else
+                    cmdLineOptions = new CommandOptions();
+            }
+
+            bool createdMutex = false;
+
+            // Mutexes are preferred when checking if a program is already running, since in theory another GameVault.exe could be running that isn't ours
+            if (!Mutex.TryOpenExisting(GAMEVAULT_MUTEX, out _))
+            {
+                // GameVault is not running
+                _ = new Mutex(true, GAMEVAULT_MUTEX, out createdMutex);
+            }
+
+            if (!createdMutex)
+            {
+                // GameVault is already running and we should send messages to that instance
+                // We can't use await here since it puts is on a non-STA thread
+
+                if (cmdLineOptions.Action == CommandOptions.ActionEnum.Query)
+                {
+                    // We're sending a query through the pipe, this is mostly for debugging
+                    var result = PipeServiceHandler.SendMessage(cmdLineOptions.UriData!, expectsResult: true).Result;
+
+                    result = result?.Trim('\r', '\n');
+
+                    // Limitation of running as WinExe, we can't write to Console.Out so, we can only show a visible version of the result
+                    if (!string.IsNullOrEmpty(result))
+                        System.Windows.MessageBox.Show(result, "Query Result", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Information);
+
+                    Environment.Exit(1);
+                    return;
+                }
+
+                PipeServiceHandler.SendMessage(cmdLineOptions.UriData, expectsResult: false).Wait();
+                Environment.Exit(1);
+                return;
+            }
+
+            PipeServiceHandler.StartInstance();
+            RunApp(cmdLineOptions);
+        }
+
+        /// <summary>
+        /// Runs the main application with the given command line
+        /// </summary>
+        // Ensure the method is not inlined, so you don't need to load any WPF dll in the Main method
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        static void RunApp(CommandOptions cmdLineOptions)
+        {
+            App.CommandLineOptions = cmdLineOptions;
+
+            var app = new App();
+            app.InitializeComponent();
+            app.Run();
+        }
+    }
+}

--- a/gamevault/Properties/launchSettings.json
+++ b/gamevault/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "gamevault": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/gamevault/UserControls/GameDownloadUserControl.xaml.cs
+++ b/gamevault/UserControls/GameDownloadUserControl.xaml.cs
@@ -51,7 +51,7 @@ namespace gamevault.UserControls
             gameSizeConverter = new GameSizeConverter();
             if (download)
             {
-                DownloadGame();
+                _ = DownloadGame();
             }
             else
             {
@@ -107,45 +107,42 @@ namespace gamevault.UserControls
 
             MainWindowViewModel.Instance.UpdateTaskbarProgress();
         }
-        private void DownloadGame()
+        private async Task DownloadGame()
         {
-            Task.Run(async () =>
+            IsDownloadActive = true;
+            ViewModel.State = "Downloading...";
+            ViewModel.DownloadUIVisibility = System.Windows.Visibility.Visible;
+            ViewModel.DownloadFailedVisibility = System.Windows.Visibility.Hidden;
+
+            if (!Directory.Exists(m_DownloadPath)) { Directory.CreateDirectory(m_DownloadPath); }
+            KeyValuePair<string, string>? header = null;
+            if (SettingsViewModel.Instance.DownloadLimit > 0)
             {
-                IsDownloadActive = true;
-                ViewModel.State = "Downloading...";
-                ViewModel.DownloadUIVisibility = System.Windows.Visibility.Visible;
-                ViewModel.DownloadFailedVisibility = System.Windows.Visibility.Hidden;
+                header = new KeyValuePair<string, string>("X-Download-Speed-Limit", SettingsViewModel.Instance.DownloadLimit.ToString());
+            }
+            client = new HttpClientDownloadWithProgress($"{SettingsViewModel.Instance.ServerUrl}/api/games/{ViewModel.Game.ID}/download", m_DownloadPath, Path.GetFileName(ViewModel.Game.FilePath), header);
+            client.ProgressChanged += DownloadProgress;
+            startTime = DateTime.Now;
 
-                if (!Directory.Exists(m_DownloadPath)) { Directory.CreateDirectory(m_DownloadPath); }
-                KeyValuePair<string, string>? header = null;
-                if (SettingsViewModel.Instance.DownloadLimit > 0)
-                {
-                    header = new KeyValuePair<string, string>("X-Download-Speed-Limit", SettingsViewModel.Instance.DownloadLimit.ToString());
-                }
-                client = new HttpClientDownloadWithProgress($"{SettingsViewModel.Instance.ServerUrl}/api/games/{ViewModel.Game.ID}/download", m_DownloadPath, Path.GetFileName(ViewModel.Game.FilePath), header);
-                client.ProgressChanged += DownloadProgress;
-                startTime = DateTime.Now;
-
-                try
-                {
-                    await client.StartDownload();
-                    await CacheHelper.CreateOfflineCacheAsync(ViewModel.Game);
-                }
-                catch (Exception ex)
-                {
-                    client.Dispose();
-                    IsDownloadActive = false;
-                    ViewModel.State = $"Error: '{ex.Message}'";
-                    ViewModel.DownloadUIVisibility = System.Windows.Visibility.Hidden;
-                    ViewModel.DownloadFailedVisibility = System.Windows.Visibility.Visible;
-                }
-            });
+            try
+            {
+                await client.StartDownload();
+                await CacheHelper.CreateOfflineCacheAsync(ViewModel.Game);
+            }
+            catch (Exception ex)
+            {
+                client.Dispose();
+                IsDownloadActive = false;
+                ViewModel.State = $"Error: '{ex.Message}'";
+                ViewModel.DownloadUIVisibility = System.Windows.Visibility.Hidden;
+                ViewModel.DownloadFailedVisibility = System.Windows.Visibility.Visible;
+            }
         }
         private void RetryDownload_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             ViewModel.DownloadInfo = string.Empty;
             ViewModel.GameDownloadProgress = 0;
-            DownloadGame();
+            _ = DownloadGame();
         }
         private void DownloadProgress(long? totalFileSize, long totalBytesDownloaded, double? progressPercentage)
         {
@@ -223,8 +220,21 @@ namespace gamevault.UserControls
 
         private async void DeleteFile_MouseLeftButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            MessageDialogResult result = await ((MetroWindow)App.Current.MainWindow).ShowMessageAsync($"Are you sure you want to delete '{(ViewModel.Game == null ? "this Game" : ViewModel.Game.Title)}' ?", "", MessageDialogStyle.AffirmativeAndNegative, new MetroDialogSettings() { AffirmativeButtonText = "Yes", NegativeButtonText = "No", AnimateHide = false });
-            if (result == MessageDialogResult.Affirmative)
+            await DeleteFile(confirm: true);
+        }
+
+        public async Task DeleteFile(bool confirm = true)
+        {
+            bool doDelete = true;
+
+            if (confirm)
+            {
+                MessageDialogResult result = await ((MetroWindow)App.Current.MainWindow).ShowMessageAsync($"Are you sure you want to delete '{(ViewModel.Game == null ? "this Game" : ViewModel.Game.Title)}' ?", "", MessageDialogStyle.AffirmativeAndNegative, new MetroDialogSettings() { AffirmativeButtonText = "Yes", NegativeButtonText = "No", AnimateHide = false });
+
+                doDelete = result == MessageDialogResult.Affirmative;
+            }
+
+            if (doDelete)
             {
                 try
                 {
@@ -244,6 +254,7 @@ namespace gamevault.UserControls
                 }
             }
         }
+
         private void OpenDirectory_MouseLeftButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             if (Directory.Exists(m_DownloadPath))

--- a/gamevault/UserControls/GameSettingsUserControl.xaml.cs
+++ b/gamevault/UserControls/GameSettingsUserControl.xaml.cs
@@ -154,6 +154,12 @@ namespace gamevault.UserControls
         private async void Uninstall_Click(object sender, MouseButtonEventArgs e)
         {
             ((FrameworkElement)sender).IsEnabled = false;
+            await UninstallGame();
+            ((FrameworkElement)sender).IsEnabled = true;
+        }
+
+        public async Task UninstallGame()
+        {
             if (ViewModel.Game.Type == GameType.WINDOWS_PORTABLE)
             {
                 MessageDialogResult result = await ((MetroWindow)App.Current.MainWindow).ShowMessageAsync($"Are you sure you want to uninstall '{ViewModel.Game.Title}' ?", "", MessageDialogStyle.AffirmativeAndNegative, new MetroDialogSettings() { AffirmativeButtonText = "Yes", NegativeButtonText = "No", AnimateHide = false });
@@ -222,8 +228,8 @@ namespace gamevault.UserControls
             {
                 MainWindowViewModel.Instance.AppBarText = "Game Type cannot be determined";
             }
-            ((FrameworkElement)sender).IsEnabled = true;
         }
+
         private void InitDiskUsagePieChart()
         {
             Task.Run(() =>

--- a/gamevault/UserControls/GameViewUserControl.xaml.cs
+++ b/gamevault/UserControls/GameViewUserControl.xaml.cs
@@ -96,6 +96,11 @@ namespace gamevault.UserControls
         }
         private void GamePlay_Click(object sender, MouseButtonEventArgs e)
         {
+            GamePlay();
+        }
+
+        public void GamePlay()
+        {
             string path = "";
             KeyValuePair<Game, string> result = InstallViewModel.Instance.InstalledGames.Where(g => g.Key.ID == ViewModel.Game.ID).FirstOrDefault();
             if (!result.Equals(default(KeyValuePair<Game, string>)))
@@ -147,6 +152,7 @@ namespace gamevault.UserControls
                 MainWindowViewModel.Instance.AppBarText = $"Could not find Executable '{savedExecutable}'";
             }
         }
+
         private void GameSettings_Click(object sender, MouseButtonEventArgs e)
         {
             if (ViewModel.Game == null)

--- a/gamevault/gamevault.csproj
+++ b/gamevault/gamevault.csproj
@@ -9,6 +9,7 @@
 		<UseWindowsForms>True</UseWindowsForms>
 		<ApplicationIcon>Resources\Images\icon.ico</ApplicationIcon>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<StartupObject>gamevault.Program</StartupObject>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -35,6 +36,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommandLineParser" Version="2.9.1" />
 		<PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc2" />
 		<PackageReference Include="Magick.NET-Q8-x64" Version="13.5.0" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.10" />


### PR DESCRIPTION
This is in direct response to #144. If this gets pulled through, I'll then probably make a plugin on for Playnite which interacts with it.

I've introduced a Program.cs + Main() entry point which is triggered before any WPF code gets loaded. This is necessary to get access to the command line arguments before they get manipulated, and speed up the response time of custom actions.

Command Line Options are parsed using https://github.com/commandlineparser/commandline which is MIT licensed.

A custom URI handler has been added in the form of `gamevault://<action>?parameters`, which hooks itself into the Windows Registry to listen globally.

Command Line options, custom URI messages and messages sent via the Named Pipe are all handled with the same `CommandOptions` base class. So anything that can be done using the command line can also be done by sending a command through the Pipe or by using the gamevault:// uri.

Without modifying the application type away from winexe, it's impossible to actually send messages back to the parent application, so any messages that have to be displayed are displayed in message boxes. The only 2 cases where this is really a problem is when `help` is called, it'd be a lot simpler to write the help the command line, and it'd also let us respond directly to a Query verb by just writing the result to the output.

### Usage
* Command-line: `gamevault.exe <action> [--param=value] [--param value]`
  * Where `[value]` can be wrapped in quotes if it contains spaces, and [param] is prefixed with 2 dashes
* URI (does not care about gamevault.exe location): `gamevault://<action>?[param=value]&[param=value]`
  * Where `[params]` and `[value]` are uri encoded
* Command-line uri (the way that Windows sends the arguments): `gamevault.exe --uridata <uri>`
* NamedPipeClientStream: Open a `NamedPipeClientStream` (or whatever language's equivalent) to the pipe named `GameVault` and then send a message in the format of `<uri>`

### Available actions & params
* `<none>` (nothing provided)
  * Only supported for direct command-line usage (gamevault.exe)
  * Just an alias for `show`, will focus the existing instance if already running
  * `minimized=[true/false]` - Optional, open the application in the background
  * `gameid=[id]` - Optional, show a specific game
* `show`
  * Shows the main application or a specific game
  * `minimized=[true/false]` - Optional, whether to open without displaying the UI
  * `gameid=[id]` - Optional, show a specific game
* `install`
  * Installs a specific game defined by `gameid`, shows the "downloads" ui and starts downloading the game
  * `gameid=[id]` - Required, the id of the game to install
* `uninstall`
  * Uninstalls a specific game defined by `gameid`, showing the "game settings" ui and confirming with the user first
  * `gameid=[id]` - Required, the id of the game to uninstall
* `start`
  * Starts a specific game defined by `gameid`, or if not installed then does the same as `install`
  * `gameid=[id]` - Required, the id of the game to start
  * `autoinstall=[true/false]` - Optional, defaults to true. If false, then the game will just be selected (same as `show`) if not already installed
* `help`
  * Only supported for direct command-line usage (gamevault.exe)
  * Displays help for the command line interface in a message box
  * `help show`, `help install`, `help uninstall`, `help start`
* `version`
  * Only supported for direct command-line usage (gamevault.exe)
  * Displays the version in a message box

### URI "query" action
When sending a request via URI, an additional action called `query` is available, which lets you get infromation from the clientside app. This is **not** a replacement for the server-side backend, and is just a way to get simple information. The specific value to query is provided in the `query` parameter, with the following available:
* `exists` - Check if the provided `gameid` exists locally or on the configured server `(True/False)`
* `installed` - Check if the provided `gameid` is installed `(True/False)`
* `downloaded` - Check if the provided `gameid` is downloaded `(True/False)`
* `getname` - Get the name of the game defined by `gameid`
* `getinstalldirectory` - Get the install directory of the game defined by `gameid`
* `getappversion` - Get the version of the application
* `getserverurl` - Get the URL that we're currently configured to point to
* `isloggedin` - Returns if the user is currently logged in `(True/False)`

### Command-line examples
* `gamevault.exe`
* `gamevault.exe --minimized=true` - Opens the app in the background
* `gamevault.exe show --gameid=3` - Opens the app and shows the game with ID 3
* `gamevault.exe install --gameid=3` - Installs the game with ID 3, or if already installed, shows it
* `gamevault.exe uninstall --gameid=3` - Uninstalls the game with ID 3, or if already uninstalled, shows it
* `gamevault.exe start --gameid=3` - Starts the game with ID 3, or if not installed, calls `install`
* `gamevault.exe start --gameid=3 --minimized=false` - Starts the game with ID 3 but also brings GameVault into view first
* `gamevault.exe start --gameid 3 --minimized false` - The same as above but without `=`
* `gamevault.exe help` - Displays the help screen
* `gamevault.exe help start` - Displays help for `start`
* `gamevault.exe --uridata "gamevault://start?gameid=3"` - The same as `gamevault.exe start --gameid=3`
* `gamevault.exe --uridata "gamevault://start?gameid=3&minimized=false"` - The same as `gamevault.exe start --gameid=3 --minimized=false`

### URI examples
* `gamevault://show`
* `gamevault://show?minimized=true`
* `gamevault://install?gameid=3`
* `gamevault://uninstall?gameid=3`
* `gamevault://start?gameid=3`
* `gamevault://start?gameid=3&minimized=false`

### Query examples (ensure the main application is running first, expected through the NamedPipe as a message)
* These can also be tested by running `gamevault.exe --uridata "<uri>"`
* `gamevault://query?query=exists&gameid=3` - True/False depending on the if the game with ID 3 exists
* `gamevault://query?query=installed&gameid=3` - True/False depending on the installed status of game with ID 3
* `gamevault://query?query=downloaded&gameid=3` - True/False depending on the downloaded status of game with ID 3
* `gamevault://query?query=getname&gameid=3` - The name of game with ID 3
* `gamevault://query?query=getinstalldirectory&gameid=3` - The install directory of the game with ID 3
* `gamevault://query?query=getappversion` - Returns the version of the app (1.8.2)
* `gamevault://query?query=getserverurl` - The URL the app is currently configured for
* `gamevault://query?query=isloggedin` - True/False depending on the login status of the app

### C# code to interact with the GameVault app through the named pipe
```
public static async Task<string> SendPipeMessage(string message, CancellationToken cancellationToken, bool expectsResult = false, int timeout = 500)
{
    string result = null;
    var client = new NamedPipeClientStream("GameVault");
    StreamWriter writer = null;
    StreamReader reader = null;

    try
    {
        await client.ConnectAsync(timeout, cancellationToken);

        writer = new StreamWriter(client, Encoding.UTF8, 1024, leaveOpen: true) { AutoFlush = true };
        await writer.WriteLineAsync(message);

        if (expectsResult)
        {
            reader = new StreamReader(client, Encoding.UTF8, false, 1024, leaveOpen: true);
            result = await reader.ReadLineAsync();
        }
    }
    finally
    {
        SafeDispose(writer);
        SafeDispose(reader);
        SafeDispose(client);
    }

    return result;
}

private static void SafeDispose(IDisposable disposable)
{
    if (disposable == null)
        return;

    try
    {
        disposable.Dispose();
    }
    catch (Exception) { }
}
```